### PR TITLE
Removing https://www.drupal.org/project/drupal/issues/3128548 patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
                 "https://www.drupal.org/project/drupal/issues/3039185": "https://www.drupal.org/files/issues/2020-04-17/allow-field-blocks-to-display-label-in-layout-builder-3039185-22.patch",
                 "https://www.drupal.org/project/drupal/issues/3106718": "https://www.drupal.org/files/issues/2020-01-16/3106718-image-hal-3.patch",
                 "https://www.drupal.org/project/drupal/issues/2577923": "https://www.drupal.org/files/issues/2020-06-11/2577923-128.patch",
-                "https://www.drupal.org/project/drupal/issues/2353611": "https://www.drupal.org/files/issues/2019-10-15/drupal-link_uuid-2353611-262.patch",
-                "https://www.drupal.org/project/drupal/issues/3128548 & https://www.drupal.org/project/ultimate_cron/issues/3184623": "https://www.drupal.org/files/issues/2020-12-03/3128548-15-StatementInterface.patch"
+                "https://www.drupal.org/project/drupal/issues/2353611": "https://www.drupal.org/files/issues/2019-10-15/drupal-link_uuid-2353611-262.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2698425": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"


### PR DESCRIPTION
No longer needed with Drupal 9.1.5 +