### PR TITLE
D8CORE-4019 Views infinite scroll template should be divs instead of lists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
                 "https://www.drupal.org/project/drupal/issues/3039185": "https://www.drupal.org/files/issues/2020-04-17/allow-field-blocks-to-display-label-in-layout-builder-3039185-22.patch",
                 "https://www.drupal.org/project/drupal/issues/3106718": "https://www.drupal.org/files/issues/2020-01-16/3106718-image-hal-3.patch",
                 "https://www.drupal.org/project/drupal/issues/2577923": "https://www.drupal.org/files/issues/2020-06-11/2577923-128.patch",
-                "https://www.drupal.org/project/drupal/issues/2353611": "https://www.drupal.org/files/issues/2019-10-15/drupal-link_uuid-2353611-262.patch"
+                "https://www.drupal.org/project/drupal/issues/2353611": "https://www.drupal.org/files/issues/2019-10-15/drupal-link_uuid-2353611-262.patch",
+                "https://www.drupal.org/project/drupal/issues/3195543": "https://git.drupalcode.org/project/drupal/-/merge_requests/278.patch"
             },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/2698425": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"
@@ -48,6 +49,9 @@
             },
             "drupal/smart_date": {
                 "https://www.drupal.org/project/smart_date/issues/3154741": "https://www.drupal.org/files/issues/2020-06-24/smart_date-anon-no-timezone-1.patch"
+            },
+            "drupal/views_infinite_scroll": {
+                "https://www.drupal.org/project/views_infinite_scroll/issues/3094488": "https://www.drupal.org/files/issues/2020-04-14/3094488-2.patch"
             },
             "drupal/views_taxonomy_term_name_depth": {
                 "https://www.drupal.org/project/views_taxonomy_term_name_depth/issues/2877249": "https://www.drupal.org/files/issues/2021-04-07/2877249-30.patch"


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Patch core and views infinite scroll module to rewrite pager to divs

Create a release after this merger

# Need Review By (Date)
- 5/30

# Urgency
- low

# Steps to Test
1. `composer require su-sws/drupal-patches:'dev-D8CORE-4019 as 8.0.6' --no-update`
1. `composer update su-sws/drupal-patches -n`
1. `rm -rf docroot/core docroot/modules/contrib/views_infinite_scroll`
1. `composer install -n`
1. create a bunch of events. at least 20
1. view the `/events` page.
1. verify the pager is not in `ul` or `li` elements.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
