### PR TITLE
removed patches for google analytics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,10 +57,6 @@
             "drupal/field_encrypt": {
                 "https://www.drupal.org/project/field_encrypt/issues/3299175": "https://git.drupalcode.org/project/field_encrypt/-/merge_requests/31.patch"  
             },
-            "drupal/google_analytics": {
-                "https://www.drupal.org/project/google_analytics/issues/3246597": "https://www.drupal.org/files/issues/2021-11-25/google_analytics-3246597-7.patch",
-                "https://www.drupal.org/project/google_analytics/issues/3295606": "https://www.drupal.org/files/issues/2022-07-12/module-handler-interface--3295606--2.patch"
-            },
             "drupal/jsonapi_extras": {
                 "https://www.drupal.org/project/jsonapi_extras/issues/3232279": "https://www.drupal.org/files/issues/2021-09-10/fix-output-schema-3232279-3.patch"
             },


### PR DESCRIPTION
New releases 4.0.1 and 4.0.2 obsoletes these patches. See also: https://www.drupal.org/project/google_analytics/releases/4.0.1