### PR TITLE
Added patch for drupal/shs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,8 @@
                 "https://www.drupal.org/project/response_code_condition/issues/3366575": "https://git.drupalcode.org/project/response_code_condition/-/merge_requests/2.patch"
             },
             "drupal/shs": {
-                "https://www.drupal.org/project/shs/issues/3047595": "https://www.drupal.org/files/issues/2022-01-06/3047595-5.patch"
+                "https://www.drupal.org/project/shs/issues/3047595": "https://www.drupal.org/files/issues/2022-01-06/3047595-5.patch",
+                "https://www.drupal.org/project/shs/issues/3436056": "https://www.drupal.org/files/issues/2024-03-26/shs-project-issue-ajax-form-3436056.patch"
             },
             "drupal/subrequests": {
                 "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"


### PR DESCRIPTION
A release of Simple hierarchical select on 3/26/24 broke the /admin/modules path.  This patch corrects it.