### PR TITLE
remove focal point patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,9 +56,6 @@
             "drupal/field_group": {
                 "https://www.drupal.org/project/field_group/issues/2969051": "https://www.drupal.org/files/issues/2023-12-19/2969051-100_2.patch"
             },
-            "drupal/focal_point": {
-                "https://www.drupal.org/project/focal_point/issues/3328807": "https://www.drupal.org/files/issues/2023-01-06/3328807-focal_point-image_width_when_no_image_to_crop.patch"
-            },
             "drupal/google_analytics": {
                 "https://www.drupal.org/project/google_analytics/issues/3373921": "https://www.drupal.org/files/issues/2023-08-07/google-analytics-issues-3373921-cannot-install-from-existing-config-11.patch"
             },


### PR DESCRIPTION
A release of the module on 5-7-2024 renders this patch moot.  See also: https://www.drupal.org/project/focal_point/releases/2.1.0