### PR TITLE
removed content_lock patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,6 @@
             "drupal/config_readonly": {
                 "https://www.drupal.org/project/config_readonly/issues/2892631": "https://www.drupal.org/files/issues/2023-07-18/config-readonly-2892631-27.patch"
             },
-            "drupal/content_lock": {
-                "https://www.drupal.org/project/content_lock/issues/3307402": "https://git.drupalcode.org/project/content_lock/-/merge_requests/11.patch"
-            },
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/2577923": "https://www.drupal.org/files/issues/2022-12-02/2577923-154.patch",
                 "Fix page parameter for JSON Api": "https://sws-devguide.stanford.edu/sites/g/files/sbiybj17516/files/core-pager-parameters.patch",


### PR DESCRIPTION
A new release on 5-15-2024 of the content_lock module makes the patch unnecessary.