### PR TITLE
Google Analytics won't allow site install unless it's on version 4.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "drupal/diff": "<1.3.0",
         "drupal/field_encrypt": "<3.2.0",
         "drupal/focal_point": "<2.0.0-alpha1",
-        "drupal/google_analytics": "<4.0.0",
         "drupal/views_infinite_scroll": "<2.0.0",
         "drupal/menu_link": "<2.0.0",
         "drupal/fast_404": "<3.0.0-rc1"


### PR DESCRIPTION
# Not Ready

I'm getting an error when running `drush site install vpge_profile`, but when I use the latest version of Google Analytics (4.0.3), it installs correctly. I'm not sure why this module is constrained but this module's new codebase seems to resolve the installation issue.

The issue replicates on my local when I run `drush site install` 

![Screenshot 2025-03-25 at 4 57 59 PM](https://github.com/user-attachments/assets/d3d5cdc4-10a0-4d82-bb6b-ce23c6298e68)
