### PR TITLE
Remove drupal/cshs patch reference from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,6 @@
                 "https://www.drupal.org/project/drupal/issues/3332063": "https://www.drupal.org/files/issues/2023-03-12/path-alias-not-available-3332063.patch",
                 "https://www.drupal.org/project/drupal/issues/3474018": "https://www.drupal.org/files/issues/2025-07-03/3474018-27.diff"
             },
-            "drupal/cshs": {
-                "https://www.drupal.org/project/cshs/issues/3559919": "https://www.drupal.org/files/issues/2025-11-25/cshs-unpublished_terms-3559919.patch"
-            },
             "drupal/default_content": {
                 "https://www.drupal.org/project/default_content/issues/3160146": "https://git.drupalcode.org/project/default_content/-/merge_requests/15.patch",
                 "https://www.drupal.org/project/default_content/issues/2698425": "https://www.drupal.org/files/issues/2020-09-02/default_content-integrity_constrait_violation-3162987-2.patch"


### PR DESCRIPTION
Removed patch reference for drupal/cshs.